### PR TITLE
Upgrade to Ohm v16 pre-release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 generated
 *.som.js
+*.ohm-recipe.*

--- a/package-lock.json
+++ b/package-lock.json
@@ -228,6 +228,34 @@
         "fastq": "^1.6.0"
       }
     },
+    "@ohm-js/cli": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@ohm-js/cli/-/cli-0.1.0.tgz",
+      "integrity": "sha512-2KKpfMVrgJoInWR+jEfidPkB/mhZzOjv8nbZKoCioJ5oWf9sIastVqDTv/TXJmTXhMl9yA2/Ekz/GcnTaPIolA==",
+      "dev": true,
+      "requires": {
+        "commander": "^8.1.0",
+        "ohm-js": "^16.0.0-pre.2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-8.2.0.tgz",
+          "integrity": "sha512-LLKxDvHeL91/8MIyTAD5BFMNtoIwztGPMiM/7Bl8rIPmHCZXRxmSWr91h57dpOpnQ6jIUqEWdXE/uBYMfiVZDA==",
+          "dev": true
+        },
+        "ohm-js": {
+          "version": "16.0.0-pre.2",
+          "resolved": "https://registry.npmjs.org/ohm-js/-/ohm-js-16.0.0-pre.2.tgz",
+          "integrity": "sha512-sonrJ+DAvKFAe5BCqFtMFrdk75IXy5BD5iGqoi4OEHmS1cXObMmmEBiKAI1b92+wd/asddoou8Cj/Zvsote9hQ==",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^2.0.4",
+            "util-extend": "^1.0.3"
+          }
+        }
+      }
+    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz",
@@ -3914,9 +3942,9 @@
       }
     },
     "ohm-js": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/ohm-js/-/ohm-js-15.5.0.tgz",
-      "integrity": "sha512-pmTx/SXZLMekLXJi0V6TEfESpPCSd5B95pWKaY+1ZIgvV5IEUiP2K3EdkESbLZ4VpO94oNCEJ2OTmQyzxSklmA==",
+      "version": "16.0.0-pre.2",
+      "resolved": "https://registry.npmjs.org/ohm-js/-/ohm-js-16.0.0-pre.2.tgz",
+      "integrity": "sha512-sonrJ+DAvKFAe5BCqFtMFrdk75IXy5BD5iGqoi4OEHmS1cXObMmmEBiKAI1b92+wd/asddoou8Cj/Zvsote9hQ==",
       "requires": {
         "is-buffer": "^2.0.4",
         "util-extend": "^1.0.3"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A JavaScript implementation of the SOM Smalltalk dialect (som-st.github.io)",
   "main": "src/index.js",
   "scripts": {
-    "test": "ava",
+    "generate": "ohm generateRecipes src/SOM.ohm",
+    "test": "npm run generate && ava",
     "lint": "prettier-standard --check && standard",
     "format": "prettier-standard --format && standard --fix",
     "generate-classes": "node scripts/generateClassLib.mjs",
@@ -13,6 +14,7 @@
   "author": "Patrick Dubroy <pdubroy@gmail.com>",
   "license": "MIT",
   "devDependencies": {
+    "@ohm-js/cli": "^0.1.0",
     "ava": "^3.15.0",
     "prettier-standard": "^16.4.1",
     "standard": "^16.0.3",
@@ -22,7 +24,7 @@
     "fnv1a": "^1.0.1",
     "js-logger": "^1.6.1",
     "minimist": "^1.2.5",
-    "ohm-js": "^15.5.0"
+    "ohm-js": "^16.0.0-pre.2"
   },
   "ava": {
     "files": [

--- a/src/paths.mjs
+++ b/src/paths.mjs
@@ -8,8 +8,6 @@ export const somTestSuitePath = path.join(
   '../third_party/SOM-st/SOM/TestSuite'
 )
 
-export const somGrammarPath = path.join(__dirname, 'SOM.ohm')
-
 export const somClassLibPath = path.join(
   __dirname,
   '../third_party/SOM-st/SOM/Smalltalk'


### PR DESCRIPTION
- Fix semantic actions that were relying on the default `_iter` action to explicitly map over the iter node's children. For example, `someIter.toJS()` is changed to `someIter.children.map(c => c.toJS())`.
- Use the new `@ohm-js/cli` package to generate a recipe for the grammar, which is a standalone module from which we can directly import and instance of the grammar.